### PR TITLE
Fix ktlint formatting issues

### DIFF
--- a/androidApp/src/main/java/com/bene/jump/MainActivity.kt
+++ b/androidApp/src/main/java/com/bene/jump/MainActivity.kt
@@ -17,10 +17,10 @@ import com.bene.jump.data.Settings
 import com.bene.jump.data.SettingsStore
 import com.bene.jump.input.TiltInput
 import com.bene.jump.input.TouchInput
+import com.bene.jump.ui.DevSettingsScreen
 import com.bene.jump.ui.GameScreen
 import com.bene.jump.ui.MenuScreen
 import com.bene.jump.ui.SettingsScreen
-import com.bene.jump.ui.DevSettingsScreen
 import com.bene.jump.ui.theme.JumpTheme
 import com.bene.jump.vm.GameViewModel
 import kotlinx.coroutines.launch

--- a/androidApp/src/main/java/com/bene/jump/data/SettingsStore.kt
+++ b/androidApp/src/main/java/com/bene/jump/data/SettingsStore.kt
@@ -47,8 +47,8 @@ class SettingsStore(private val context: Context) {
                 multiplayerEnabled = prefs[multiplayerKey] ?: false,
                 wsUrl = prefs[wsUrlKey] ?: Settings.DEFAULT_WS_URL,
                 inputBatchEnabled = prefs[inputBatchKey] ?: true,
-                interpolationDelayMs = prefs[interpolationDelayKey]
-                    ?: Settings.DEFAULT_INTERPOLATION_DELAY_MS,
+                interpolationDelayMs =
+                    prefs[interpolationDelayKey] ?: Settings.DEFAULT_INTERPOLATION_DELAY_MS,
             )
         }
 

--- a/androidApp/src/main/java/com/bene/jump/vm/GameViewModel.kt
+++ b/androidApp/src/main/java/com/bene/jump/vm/GameViewModel.kt
@@ -121,7 +121,12 @@ class GameViewModel(
                         interpolationDelayMs = settings.interpolationDelayMs,
                     ),
                 )
-            } else if (previous == null || previous.wsUrl != settings.wsUrl || previous.inputBatchEnabled != settings.inputBatchEnabled || previous.interpolationDelayMs != settings.interpolationDelayMs) {
+            } else if (
+                previous == null ||
+                previous.wsUrl != settings.wsUrl ||
+                previous.inputBatchEnabled != settings.inputBatchEnabled ||
+                previous.interpolationDelayMs != settings.interpolationDelayMs
+            ) {
                 netController?.stop()
                 netController =
                     NetController(

--- a/core/src/commonMain/kotlin/com/bene/jump/core/net/Checksums.kt
+++ b/core/src/commonMain/kotlin/com/bene/jump/core/net/Checksums.kt
@@ -8,7 +8,11 @@ private const val FNV_PRIME = 0x100000001b3L
 private const val MASK_64 = -0x1L
 
 object Checksums {
-    fun compute(state: CompactState, world: World, platformSample: Int = 4): Long {
+    fun compute(
+        state: CompactState,
+        world: World,
+        platformSample: Int = 4,
+    ): Long {
         var hash = FNV_OFFSET_BASIS
         hash = mixFloat(hash, state.x)
         hash = mixFloat(hash, state.y)
@@ -27,14 +31,32 @@ object Checksums {
         return hash
     }
 
-    fun computeHex(state: CompactState, world: World, platformSample: Int = 4): String =
-        compute(state, world, platformSample).toULong().toString(16)
+    fun computeHex(
+        state: CompactState,
+        world: World,
+        platformSample: Int = 4,
+    ): String {
+        return compute(state, world, platformSample).toULong().toString(16)
+    }
 
-    private fun mixFloat(hash: Long, value: Float): Long = mixInt(hash, value.toRawBits())
+    private fun mixFloat(
+        hash: Long,
+        value: Float,
+    ): Long {
+        return mixInt(hash, value.toRawBits())
+    }
 
-    private fun mixInt(hash: Long, value: Int): Long = mixLong(hash, value.toLong() and 0xFFFFFFFFL)
+    private fun mixInt(
+        hash: Long,
+        value: Int,
+    ): Long {
+        return mixLong(hash, value.toLong() and 0xFFFFFFFFL)
+    }
 
-    private fun mixLong(hash: Long, value: Long): Long {
+    private fun mixLong(
+        hash: Long,
+        value: Long,
+    ): Long {
         var h = hash
         var v = value
         for (i in 0 until 8) {
@@ -44,7 +66,10 @@ object Checksums {
         return h
     }
 
-    private fun mixByte(hash: Long, byte: Int): Long {
+    private fun mixByte(
+        hash: Long,
+        byte: Int,
+    ): Long {
         val v = byte.toLong() and 0xFF
         return ((hash xor v) * FNV_PRIME) and MASK_64
     }

--- a/core/src/commonMain/kotlin/com/bene/jump/core/net/Interpolator.kt
+++ b/core/src/commonMain/kotlin/com/bene/jump/core/net/Interpolator.kt
@@ -9,17 +9,28 @@ class Interpolator(
 ) {
     private val buffers = mutableMapOf<String, StateBuffer>()
 
-    fun push(playerId: String, sampleTimeMs: Long, state: CompactState) {
+    fun push(
+        playerId: String,
+        sampleTimeMs: Long,
+        state: CompactState,
+    ) {
         val buffer = buffers.getOrPut(playerId) { StateBuffer(bufferSize) }
         buffer.push(sampleTimeMs, state)
     }
 
-    fun sample(playerId: String, renderTimeMs: Long, out: CompactState): Boolean {
+    fun sample(
+        playerId: String,
+        renderTimeMs: Long,
+        out: CompactState,
+    ): Boolean {
         val buffer = buffers[playerId] ?: return false
         return buffer.sample(renderTimeMs, maxExtrapolationMs, out)
     }
 
-    fun prune(renderTimeMs: Long, keepWindowMs: Long) {
+    fun prune(
+        renderTimeMs: Long,
+        keepWindowMs: Long,
+    ) {
         val cutoff = renderTimeMs - keepWindowMs
         buffers.values.forEach { it.prune(cutoff) }
     }
@@ -45,7 +56,10 @@ class Interpolator(
             }
         }
 
-        fun push(sampleTimeMs: Long, state: CompactState) {
+        fun push(
+            sampleTimeMs: Long,
+            state: CompactState,
+        ) {
             val index = (head + size) and mask
             states[index].copyFrom(state)
             times[index] = sampleTimeMs
@@ -56,7 +70,11 @@ class Interpolator(
             }
         }
 
-        fun sample(renderTimeMs: Long, maxExtrapolationMs: Long, out: CompactState): Boolean {
+        fun sample(
+            renderTimeMs: Long,
+            maxExtrapolationMs: Long,
+            out: CompactState,
+        ): Boolean {
             if (size == 0) return false
             val newestIndex = (head + size - 1) and mask
             val newestTime = times[newestIndex]
@@ -108,7 +126,12 @@ class Interpolator(
             }
         }
 
-        private fun interpolate(a: CompactState, b: CompactState, t: Float, out: CompactState) {
+        private fun interpolate(
+            a: CompactState,
+            b: CompactState,
+            t: Float,
+            out: CompactState,
+        ) {
             val clamped = min(1f, max(0f, t))
             out.x = lerp(a.x, b.x, clamped)
             out.y = lerp(a.y, b.y, clamped)
@@ -116,6 +139,12 @@ class Interpolator(
             out.vy = lerp(a.vy, b.vy, clamped)
         }
 
-        private fun lerp(a: Float, b: Float, t: Float): Float = a + (b - a) * t
+        private fun lerp(
+            a: Float,
+            b: Float,
+            t: Float,
+        ): Float {
+            return a + (b - a) * t
+        }
     }
 }

--- a/core/src/commonMain/kotlin/com/bene/jump/core/net/Wire.kt
+++ b/core/src/commonMain/kotlin/com/bene/jump/core/net/Wire.kt
@@ -238,39 +238,56 @@ fun C2SJoin.asEnvelope(
 fun C2SInput.asEnvelope(
     seq: Int,
     ts: Long,
-): Envelope<C2SInput> = Envelope("input", PROTOCOL_VERSION, seq, ts, this)
+): Envelope<C2SInput> {
+    return Envelope("input", PROTOCOL_VERSION, seq, ts, this)
+}
 
 fun C2SInputBatch.asEnvelope(
     seq: Int,
     ts: Long,
-): Envelope<C2SInputBatch> = Envelope("input_batch", PROTOCOL_VERSION, seq, ts, this)
+): Envelope<C2SInputBatch> {
+    return Envelope("input_batch", PROTOCOL_VERSION, seq, ts, this)
+}
 
 fun C2SPing.asEnvelope(
     seq: Int,
     ts: Long,
-): Envelope<C2SPing> = Envelope("ping", PROTOCOL_VERSION, seq, ts, this)
+): Envelope<C2SPing> {
+    return Envelope("ping", PROTOCOL_VERSION, seq, ts, this)
+}
 
 fun C2SReconnect.asEnvelope(
     seq: Int,
     ts: Long,
-): Envelope<C2SReconnect> = Envelope("reconnect", PROTOCOL_VERSION, seq, ts, this)
+): Envelope<C2SReconnect> {
+    return Envelope("reconnect", PROTOCOL_VERSION, seq, ts, this)
+}
 
-inline fun <reified T> Envelope<T>.encode(): String where T : Any, T : C2SMessage =
-    encodeEnvelope(this, serializer())
+inline fun <reified T> Envelope<T>.encode(): String where T : Any, T : C2SMessage {
+    return encodeEnvelope(this, serializer())
+}
 
-inline fun <reified T> decodeEnvelope(json: String): Envelope<T> =
-    NetworkJson.decodeFromString(Envelope.serializer(serializer()), json)
+inline fun <reified T> decodeEnvelope(json: String): Envelope<T> {
+    return NetworkJson.decodeFromString(Envelope.serializer(serializer()), json)
+}
 
-inline fun <reified T> serializer(): KSerializer<T> = kotlinx.serialization.serializer()
+inline fun <reified T> serializer(): KSerializer<T> {
+    return kotlinx.serialization.serializer()
+}
 
-fun encodeC2S(message: C2SMessage, seq: Int, ts: Long): String =
-    when (message) {
+fun encodeC2S(
+    message: C2SMessage,
+    seq: Int,
+    ts: Long,
+): String {
+    return when (message) {
         is C2SJoin -> encodeEnvelope(Envelope("join", PROTOCOL_VERSION, seq, ts, message), C2SJoin.serializer())
         is C2SInput -> encodeEnvelope(Envelope("input", PROTOCOL_VERSION, seq, ts, message), C2SInput.serializer())
         is C2SInputBatch -> encodeEnvelope(Envelope("input_batch", PROTOCOL_VERSION, seq, ts, message), C2SInputBatch.serializer())
         is C2SPing -> encodeEnvelope(Envelope("ping", PROTOCOL_VERSION, seq, ts, message), C2SPing.serializer())
         is C2SReconnect -> encodeEnvelope(Envelope("reconnect", PROTOCOL_VERSION, seq, ts, message), C2SReconnect.serializer())
     }
+}
 
 fun decodeS2C(json: String): Envelope<S2CMessage>? {
     val raw = NetworkJson.decodeFromString(RawEnvelope.serializer(), json)


### PR DESCRIPTION
## Summary
- format checksum helpers and network serialization utilities to wrap parameters in a ktlint-friendly style
- reformat Android networking classes to satisfy ktlint multiline expression and import ordering rules
- wrap long expressions in settings storage and view model logic to stay within ktlint limits

## Testing
- `./gradlew ktlintCheck`


------
https://chatgpt.com/codex/tasks/task_e_68d4f27d27b8832daa91f7b51070de54