### PR TITLE
Add protocol v1.2 network scaffolding

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -16,6 +16,9 @@ android {
         versionCode = 1
         versionName = "0.1.0"
         vectorDrawables.useSupportLibrary = true
+        buildConfigField("String", "API_BASE", "\"http://10.0.2.2:8080\"")
+        buildConfigField("String", "WS_URL", "\"ws://10.0.2.2:8081/v1/ws\"")
+        buildConfigField("int", "PROTOCOL_PV", "1")
     }
 
     buildTypes {
@@ -43,6 +46,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     composeOptions {
@@ -75,10 +79,8 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.coroutines.android)
     implementation(libs.androidx.datastore)
-    implementation(libs.ktor.client.core)
-    implementation(libs.ktor.client.okhttp)
-    implementation(libs.ktor.client.websockets)
-    implementation(libs.ktor.client.logging)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging)
 
     debugImplementation(libs.compose.ui.tooling)
     debugImplementation(libs.leakcanary.android)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ kotlin = "2.0.20"
 kotlinxSerialization = "1.7.3"
 kotlinxDatetime = "0.6.0"
 ktor = "3.0.1"
+okhttp = "4.12.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivityCompose" }
@@ -40,6 +41,8 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
 
 [bundles]


### PR DESCRIPTION
## Summary
- tighten network serialization and extend the shared protocol model with lobby/countdown roles for v1.2
- replace the realtime socket layer with an OkHttp-based client that understands the new envelopes and heartbeats
- add emulator-friendly BuildConfig endpoints and OkHttp dependencies to the Android app configuration

## Testing
- ./gradlew :androidApp:assembleDebug *(fails: Gradle could not locate a Java 17 toolchain in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d522e3ca0c832d91d4b4a91f601cf4