### PR TITLE
Fix remaining ktlint violations

### DIFF
--- a/androidApp/src/main/java/com/bene/jump/di/AppModule.kt
+++ b/androidApp/src/main/java/com/bene/jump/di/AppModule.kt
@@ -30,15 +30,21 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideSettingsStore(@ApplicationContext context: Context): SettingsStore = SettingsStore(context)
+    fun provideSettingsStore(
+        @ApplicationContext context: Context,
+    ): SettingsStore = SettingsStore(context)
 
     @Provides
     @Singleton
-    fun provideNetPrefsStore(@ApplicationContext context: Context): NetPrefsStore = NetPrefsStore(context)
+    fun provideNetPrefsStore(
+        @ApplicationContext context: Context,
+    ): NetPrefsStore = NetPrefsStore(context)
 
     @Provides
     @Singleton
-    fun provideTiltInput(@ApplicationContext context: Context): TiltInput = TiltInput(context)
+    fun provideTiltInput(
+        @ApplicationContext context: Context,
+    ): TiltInput = TiltInput(context)
 
     @Provides
     @Singleton

--- a/androidApp/src/main/java/com/bene/jump/net/NetController.kt
+++ b/androidApp/src/main/java/com/bene/jump/net/NetController.kt
@@ -22,8 +22,8 @@ import com.bene.jump.core.net.S2CPlayerPresence
 import com.bene.jump.core.net.S2CPong
 import com.bene.jump.core.net.S2CRoleChanged
 import com.bene.jump.core.net.S2CSnapshot
-import com.bene.jump.core.net.S2CStartCountdown
 import com.bene.jump.core.net.S2CStart
+import com.bene.jump.core.net.S2CStartCountdown
 import com.bene.jump.core.net.S2CWelcome
 import com.bene.jump.core.net.asEnvelope
 import com.bene.jump.data.NetPrefsStore
@@ -415,13 +415,21 @@ class NetController(
         stateFlow.update { it.copy(role = role) }
     }
 
-    private fun onPong(serverTs: Long, pong: S2CPong) {
+    private fun onPong(
+        serverTs: Long,
+        pong: S2CPong,
+    ) {
         val now = clock()
         val rtt = (now - pong.t0).coerceAtLeast(0L)
         val skew = (((pong.t1 + serverTs) / 2.0) - ((pong.t0 + now) / 2.0)).roundToInt()
         rttMs = rtt.toInt()
         skewMs = skew
-        stateFlow.update { it.copy(rttMs = rttMs, skewMs = skewMs) }
+        stateFlow.update {
+            it.copy(
+                rttMs = rttMs,
+                skewMs = skewMs,
+            )
+        }
     }
 
     private fun drainSnapshots() {

--- a/androidApp/src/main/java/com/bene/jump/net/NetRepository.kt
+++ b/androidApp/src/main/java/com/bene/jump/net/NetRepository.kt
@@ -139,7 +139,10 @@ class NetRepository(
         )
     }
 
-    private fun buildSocketUrl(base: String, token: String): String {
+    private fun buildSocketUrl(
+        base: String,
+        token: String,
+    ): String {
         if (base.contains("token=")) return base
         val separator = if (base.contains('?')) '&' else '?'
         val encoded = URLEncoder.encode(token, StandardCharsets.UTF_8.name())


### PR DESCRIPTION
## Summary
- expand NetController's pong handler signature onto separate lines per ktlint parameter rules
- reorder RtSocket imports so the alias import trails java/kotlin groups, satisfying ktlint's lexicographic requirement

## Testing
- `TERM=dumb ./gradlew ktlintCheck`


------
https://chatgpt.com/codex/tasks/task_e_68d54a9259ac832dbc12b04ae68f4fd1