### PR TITLE
Add multiplayer lobby with character selection

### DIFF
--- a/androidApp/src/main/java/com/bene/jump/MainActivity.kt
+++ b/androidApp/src/main/java/com/bene/jump/MainActivity.kt
@@ -3,6 +3,7 @@ package com.bene.jump
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,22 +14,31 @@ import androidx.lifecycle.ViewModelProvider
 import com.bene.jump.analytics.AnalyticsRegistry
 import com.bene.jump.analytics.LogAnalyticsService
 import com.bene.jump.core.model.SessionPhase
+import com.bene.jump.core.net.RoomState
+import com.bene.jump.data.NetPrefsStore
 import com.bene.jump.data.Settings
 import com.bene.jump.data.SettingsStore
 import com.bene.jump.input.TiltInput
 import com.bene.jump.input.TouchInput
+import com.bene.jump.net.api.RoomsApi
 import com.bene.jump.ui.DevSettingsScreen
 import com.bene.jump.ui.GameScreen
+import com.bene.jump.ui.LobbyRoomScreen
+import com.bene.jump.ui.LobbySetupScreen
 import com.bene.jump.ui.MenuScreen
 import com.bene.jump.ui.SettingsScreen
 import com.bene.jump.ui.theme.JumpTheme
 import com.bene.jump.vm.GameViewModel
+import com.bene.jump.vm.LobbyStatus
 import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
 
 class MainActivity : ComponentActivity() {
     private lateinit var settingsStore: SettingsStore
     private lateinit var tiltInput: TiltInput
     private lateinit var touchInput: TouchInput
+    private lateinit var netPrefsStore: NetPrefsStore
+    private lateinit var roomsApi: RoomsApi
     private lateinit var gameViewModel: GameViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -36,21 +46,48 @@ class MainActivity : ComponentActivity() {
         settingsStore = SettingsStore(applicationContext)
         tiltInput = TiltInput(this)
         touchInput = TouchInput()
+        netPrefsStore = NetPrefsStore(applicationContext)
+        roomsApi = RoomsApi(OkHttpClient.Builder().retryOnConnectionFailure(true).build())
         AnalyticsRegistry.service = LogAnalyticsService()
         val factory =
             object : ViewModelProvider.Factory {
                 @Suppress("UNCHECKED_CAST")
                 override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
-                    return GameViewModel(settingsStore, tiltInput, touchInput, seed = 42L) as T
+                    return GameViewModel(
+                        settingsStore = settingsStore,
+                        tiltInput = tiltInput,
+                        touchInput = touchInput,
+                        roomsApi = roomsApi,
+                        netPrefsStore = netPrefsStore,
+                        seed = 42L,
+                    ) as T
                 }
             }
         gameViewModel = ViewModelProvider(this, factory)[GameViewModel::class.java]
 
         setContent {
             val state by gameViewModel.state.collectAsState()
+            val netState by gameViewModel.netState.collectAsState()
             val settings by settingsStore.settings.collectAsState(initial = Settings())
+            val lobbyState by gameViewModel.lobbyState.collectAsState()
             var screen by remember { mutableStateOf(Screen.Menu) }
             val scope = rememberCoroutineScope()
+
+            LaunchedEffect(lobbyState.status) {
+                if (screen == Screen.LobbySetup && lobbyState.status == LobbyStatus.InRoom) {
+                    screen = Screen.LobbyRoom
+                }
+                if (screen == Screen.LobbyRoom && lobbyState.status == LobbyStatus.Idle && netState.roomId == null) {
+                    screen = Screen.Menu
+                }
+            }
+            LaunchedEffect(netState.roomState) {
+                if (screen == Screen.LobbyRoom && netState.roomState == RoomState.RUNNING) {
+                    screen = Screen.Game
+                } else if (screen == Screen.Game && netState.roomState == RoomState.FINISHED) {
+                    screen = Screen.Menu
+                }
+            }
 
             JumpTheme(darkTheme = settings.darkTheme) {
                 when (screen) {
@@ -58,8 +95,7 @@ class MainActivity : ComponentActivity() {
                         MenuScreen(
                             canResume = state.phase == SessionPhase.Paused,
                             onPlay = {
-                                gameViewModel.restart(seed = 42L)
-                                screen = Screen.Game
+                                screen = Screen.LobbySetup
                             },
                             onResume = {
                                 screen = Screen.Game
@@ -74,7 +110,34 @@ class MainActivity : ComponentActivity() {
                             onTogglePause = { gameViewModel.togglePause() },
                             onRestart = { gameViewModel.restart(seed = 42L) },
                             onTouchChange = { touchInput.onTouch(it) },
-                            onBackToMenu = { screen = Screen.Menu },
+                            onBackToMenu = {
+                                gameViewModel.leaveLobby()
+                                screen = Screen.Menu
+                            },
+                        )
+                    Screen.LobbySetup ->
+                        LobbySetupScreen(
+                            lobbyState = lobbyState,
+                            onCreateRoom = { name, region, maxPlayers, mode ->
+                                gameViewModel.createRoom(name, region, maxPlayers, mode)
+                            },
+                            onJoinRoom = { roomId, name -> gameViewModel.joinRoom(roomId, name) },
+                            onBack = {
+                                gameViewModel.leaveLobby()
+                                screen = Screen.Menu
+                            },
+                        )
+                    Screen.LobbyRoom ->
+                        LobbyRoomScreen(
+                            lobbyState = lobbyState,
+                            netState = netState,
+                            onSelectCharacter = { characterId -> gameViewModel.selectCharacter(characterId) },
+                            onReadyChanged = { ready -> gameViewModel.setReady(ready) },
+                            onStart = { countdown -> gameViewModel.requestStart(countdown) },
+                            onLeave = {
+                                gameViewModel.leaveLobby()
+                                screen = Screen.Menu
+                            },
                         )
                     Screen.Settings ->
                         SettingsScreen(
@@ -126,6 +189,8 @@ class MainActivity : ComponentActivity() {
     private enum class Screen {
         Menu,
         Game,
+        LobbySetup,
+        LobbyRoom,
         Settings,
         DevSettings,
     }

--- a/androidApp/src/main/java/com/bene/jump/net/NetController.kt
+++ b/androidApp/src/main/java/com/bene/jump/net/NetController.kt
@@ -96,6 +96,7 @@ class NetController(
     private val pendingSeq = AtomicInteger(1)
     private var interpolationDelayMs: Long = 100L
     private var useInputBatch: Boolean = true
+    private var lobbyMaxPlayers: Int = 0
 
     fun start(config: Config) {
         this.config = config
@@ -298,6 +299,7 @@ class NetController(
         remotePlayerStates.clear()
         awaitingStart = welcome.roomState != RoomState.RUNNING
         val lobbyPlayers = welcome.lobby?.players.orEmpty()
+        lobbyMaxPlayers = welcome.lobby?.maxPlayers ?: lobbyMaxPlayers
         if (roomState == RoomState.RUNNING) {
             phase = ConnectionPhase.Running
         } else if (roomState == RoomState.FINISHED) {
@@ -314,6 +316,7 @@ class NetController(
                 role = role,
                 roomState = roomState,
                 lobby = lobbyPlayers,
+                lobbyMaxPlayers = lobbyMaxPlayers,
                 countdown = countdown,
                 resumeToken = welcome.resumeToken,
                 ackTick = null,
@@ -389,6 +392,7 @@ class NetController(
             it.copy(
                 roomState = roomState,
                 lobby = state.players,
+                lobbyMaxPlayers = state.maxPlayers,
                 countdown = countdown,
             )
         }

--- a/androidApp/src/main/java/com/bene/jump/net/NetState.kt
+++ b/androidApp/src/main/java/com/bene/jump/net/NetState.kt
@@ -21,6 +21,7 @@ data class NetState(
     val role: Role = Role.MEMBER,
     val roomState: RoomState = RoomState.LOBBY,
     val lobby: List<LobbyPlayer> = emptyList(),
+    val lobbyMaxPlayers: Int = 0,
     val countdown: S2CStartCountdown? = null,
     val playerId: String? = null,
     val resumeToken: String? = null,

--- a/androidApp/src/main/java/com/bene/jump/net/api/RoomsApi.kt
+++ b/androidApp/src/main/java/com/bene/jump/net/api/RoomsApi.kt
@@ -68,6 +68,18 @@ class RoomsApi(
         )
     }
 
+    suspend fun setCharacter(
+        roomId: String,
+        request: CharacterRequest,
+    ) {
+        execute<CharacterRequest, Unit>(
+            method = "POST",
+            path = "/v1/rooms/${'$'}roomId/character",
+            body = request,
+            accept = setOf(204),
+        )
+    }
+
     suspend fun startRoom(
         roomId: String,
         request: StartRoomRequest,
@@ -190,6 +202,9 @@ data class JoinRoomResponse(
 
 @Serializable
 data class ReadyRequest(val ready: Boolean)
+
+@Serializable
+data class CharacterRequest(val characterId: String)
 
 @Serializable
 data class StartRoomRequest(val countdownSec: Int? = null)

--- a/androidApp/src/main/java/com/bene/jump/ui/LobbyScreens.kt
+++ b/androidApp/src/main/java/com/bene/jump/ui/LobbyScreens.kt
@@ -1,0 +1,319 @@
+@file:Suppress("FunctionName")
+
+package com.bene.jump.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.bene.jump.core.net.Role
+import com.bene.jump.core.net.RoomState
+import com.bene.jump.net.NetState
+import com.bene.jump.vm.LobbyStatus
+import com.bene.jump.vm.LobbyUiState
+
+private data class CharacterPresentation(val name: String, val swatch: Color)
+
+private val CharacterCatalog = mapOf(
+    "jumper_red" to CharacterPresentation("Red Rocket", Color(0xFFE57373)),
+    "jumper_blue" to CharacterPresentation("Blue Comet", Color(0xFF64B5F6)),
+    "jumper_green" to CharacterPresentation("Green Glide", Color(0xFF81C784)),
+    "jumper_yellow" to CharacterPresentation("Golden Leap", Color(0xFFFFF176)),
+)
+
+@Composable
+fun LobbySetupScreen(
+    lobbyState: LobbyUiState,
+    onCreateRoom: (name: String, region: String?, maxPlayers: Int?, mode: String?) -> Unit,
+    onJoinRoom: (roomId: String, name: String) -> Unit,
+    onBack: () -> Unit,
+) {
+    var name by remember { mutableStateOf(lobbyState.playerName.ifBlank { "" }) }
+    var roomId by remember { mutableStateOf("") }
+    var region by remember { mutableStateOf("") }
+    var maxPlayers by remember { mutableStateOf("4") }
+    var mode by remember { mutableStateOf("endless") }
+
+    LaunchedEffect(lobbyState.playerName) {
+        if (lobbyState.playerName.isNotBlank() && name.isBlank()) {
+            name = lobbyState.playerName
+        }
+    }
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(text = "Multiplayer Lobby", style = MaterialTheme.typography.headlineMedium)
+        Text(text = "Choose a name and either create a lobby or join an existing one.", style = MaterialTheme.typography.bodyMedium)
+        OutlinedTextField(
+            value = name,
+            onValueChange = { name = it },
+            label = { Text("Player name") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = region,
+            onValueChange = { region = it },
+            label = { Text("Region (optional)") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = maxPlayers,
+            onValueChange = { maxPlayers = it.filter { ch -> ch.isDigit() } },
+            label = { Text("Max players") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = mode,
+            onValueChange = { mode = it },
+            label = { Text("Mode (optional)") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Button(
+            onClick = {
+                val max = maxPlayers.toIntOrNull()
+                val regionValue = region.ifBlank { null }
+                val modeValue = mode.ifBlank { null }
+                onCreateRoom(name.trim(), regionValue, max, modeValue)
+            },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = lobbyState.status != LobbyStatus.Creating && lobbyState.loading.not(),
+        ) {
+            Text("Create room")
+        }
+        Spacer(modifier = Modifier.size(12.dp))
+        OutlinedTextField(
+            value = roomId,
+            onValueChange = { roomId = it.uppercase() },
+            label = { Text("Room code") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Button(
+            onClick = { onJoinRoom(roomId.trim(), name.trim()) },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = lobbyState.status != LobbyStatus.Joining && lobbyState.loading.not(),
+        ) {
+            Text("Join room")
+        }
+        Button(onClick = onBack, modifier = Modifier.fillMaxWidth()) { Text("Back") }
+        lobbyState.errorMessage?.let {
+            Text(text = it, color = MaterialTheme.colorScheme.error)
+        }
+    }
+}
+
+@Composable
+fun LobbyRoomScreen(
+    lobbyState: LobbyUiState,
+    netState: NetState,
+    onSelectCharacter: (String) -> Unit,
+    onReadyChanged: (Boolean) -> Unit,
+    onStart: (Int?) -> Unit,
+    onLeave: () -> Unit,
+) {
+    val players = lobbyState.players
+    val maxPlayers = lobbyState.maxPlayers.takeIf { it > 0 } ?: netState.lobbyMaxPlayers
+    val selectedCharacter = lobbyState.selectedCharacter
+    val takenBy = players.associate { player -> player.characterId to player.name }
+    var countdown by remember { mutableStateOf("3") }
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(text = "Lobby", style = MaterialTheme.typography.headlineMedium)
+        Text(text = "Room: ${lobbyState.roomId ?: "-"}", style = MaterialTheme.typography.bodyMedium)
+        Text(
+            text = "Players (${players.size}${maxPlayers.takeIf { it > 0 }?.let { "/$it" } ?: ""})",
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            if (players.isEmpty()) {
+                Text(text = "Waiting for players…", style = MaterialTheme.typography.bodyMedium)
+            } else {
+                players.forEach { player ->
+                    val roleLabel = if (player.role == Role.MASTER) " (Host)" else ""
+                    val readyLabel = if (player.ready) "Ready" else "Not ready"
+                    val characterLabel = player.characterId?.let { CharacterCatalog[it]?.name ?: it } ?: "No character"
+                    Surface(
+                        tonalElevation = 2.dp,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Row(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(12.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                Text(text = player.name + roleLabel, fontWeight = FontWeight.SemiBold)
+                                Text(text = characterLabel, style = MaterialTheme.typography.bodySmall)
+                            }
+                            Text(text = readyLabel, style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
+                }
+            }
+        }
+        Text(text = "Choose your character", style = MaterialTheme.typography.titleMedium)
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            lobbyState.availableCharacters.forEach { characterId ->
+                val info = CharacterCatalog[characterId] ?: CharacterPresentation(characterId, MaterialTheme.colorScheme.primary)
+                val isSelected = characterId == selectedCharacter
+                val claimedBy = takenBy[characterId]?.takeIf { it != lobbyState.playerName }
+                CharacterChip(
+                    characterId = characterId,
+                    info = info,
+                    selected = isSelected,
+                    takenBy = claimedBy,
+                    enabled = lobbyState.roomState == RoomState.LOBBY,
+                    onClick = { onSelectCharacter(characterId) },
+                )
+            }
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            val readyText = if (lobbyState.ready) "Unready" else "Ready"
+            Button(
+                onClick = { onReadyChanged(!lobbyState.ready) },
+                enabled = lobbyState.roomState == RoomState.LOBBY,
+            ) {
+                Text(readyText)
+            }
+            if (lobbyState.role == Role.MASTER) {
+                OutlinedTextField(
+                    value = countdown,
+                    onValueChange = { value -> countdown = value.filter { it.isDigit() }.take(2) },
+                    label = { Text("Countdown (s)") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                    colors = TextFieldDefaults.outlinedTextFieldColors(),
+                )
+                val allReady = players.isNotEmpty() && players.all { it.ready }
+                Button(
+                    onClick = { onStart(countdown.toIntOrNull()) },
+                    enabled = lobbyState.roomState == RoomState.LOBBY && allReady,
+                ) {
+                    Text("Start")
+                }
+            }
+        }
+        lobbyState.countdown?.let { countdownState ->
+            val secondsRemaining = countdownState.countdownSec
+            Text(
+                text = "Starting in ${secondsRemaining}s",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        lobbyState.errorMessage?.let {
+            Text(text = it, color = MaterialTheme.colorScheme.error)
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Button(onClick = onLeave, modifier = Modifier.fillMaxWidth()) { Text("Leave lobby") }
+    }
+}
+
+@Composable
+private fun CharacterChip(
+    characterId: String,
+    info: CharacterPresentation,
+    selected: Boolean,
+    takenBy: String?,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val borderColor =
+        when {
+            selected -> MaterialTheme.colorScheme.primary
+            takenBy != null -> MaterialTheme.colorScheme.outline
+            else -> MaterialTheme.colorScheme.outline.copy(alpha = 0.6f)
+        }
+    val label = info.name
+    Surface(
+        tonalElevation = if (selected) 6.dp else 0.dp,
+        shape = RoundedCornerShape(12.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(enabled = enabled) { onClick() },
+        border = BorderStroke(1.dp, borderColor),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(32.dp)
+                            .background(info.swatch, shape = RoundedCornerShape(6.dp))
+                            .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(6.dp)),
+                )
+                Column {
+                    Text(text = label, fontWeight = FontWeight.Medium)
+                    val subtitle =
+                        when {
+                            selected -> "You"
+                            takenBy != null -> "Taken by $takenBy"
+                            else -> "Available"
+                        }
+                    Text(text = subtitle, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+            if (selected) {
+                Text(text = "Selected", color = MaterialTheme.colorScheme.primary, fontSize = 12.sp, textAlign = TextAlign.End)
+            }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/bene/jump/vm/LobbyUiState.kt
+++ b/androidApp/src/main/java/com/bene/jump/vm/LobbyUiState.kt
@@ -1,0 +1,34 @@
+package com.bene.jump.vm
+
+import com.bene.jump.core.net.LobbyPlayer
+import com.bene.jump.core.net.Role
+import com.bene.jump.core.net.RoomState
+import com.bene.jump.core.net.S2CStartCountdown
+
+enum class LobbyStatus {
+    Idle,
+    Creating,
+    Joining,
+    InRoom,
+    Error,
+}
+
+data class LobbyUiState(
+    val status: LobbyStatus = LobbyStatus.Idle,
+    val roomId: String? = null,
+    val playerName: String = "",
+    val role: Role = Role.MEMBER,
+    val roomState: RoomState = RoomState.LOBBY,
+    val players: List<LobbyPlayer> = emptyList(),
+    val maxPlayers: Int = 0,
+    val countdown: S2CStartCountdown? = null,
+    val availableCharacters: List<String> = DEFAULT_CHARACTERS,
+    val selectedCharacter: String? = null,
+    val ready: Boolean = false,
+    val errorMessage: String? = null,
+    val loading: Boolean = false,
+) {
+    companion object {
+        val DEFAULT_CHARACTERS = listOf("jumper_red", "jumper_blue", "jumper_green", "jumper_yellow")
+    }
+}

--- a/core/src/commonMain/kotlin/com/bene/jump/core/net/Wire.kt
+++ b/core/src/commonMain/kotlin/com/bene/jump/core/net/Wire.kt
@@ -67,6 +67,7 @@ data class LobbyPlayer(
     val name: String,
     val ready: Boolean,
     val role: Role,
+    val characterId: String? = null,
 )
 
 @Serializable
@@ -188,7 +189,7 @@ data class S2CWelcome(
     @Serializable
     data class LobbySnapshot(
         val players: List<LobbyPlayer>,
-        val maxPlayers: Int,
+        val maxPlayers: Int = 0,
     )
 }
 
@@ -197,6 +198,7 @@ data class S2CWelcome(
 data class S2CLobbyState(
     val roomState: RoomState,
     val players: List<LobbyPlayer>,
+    val maxPlayers: Int = 0,
 ) : S2CMessage
 
 @Serializable


### PR DESCRIPTION
## Summary
- extend the protocol spec with lobby character identifiers and the REST endpoint for selecting them
- update shared wire models, NetController, and repository to propagate lobby player characters and max player counts
- add lobby setup/room Compose screens and integrate GameViewModel/MainActivity with room creation, joining, ready toggles, and character selection

## Testing
- `./gradlew :androidApp:compileDebugKotlin` *(fails: Java 17 toolchain not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d54fd7af18832d959dfae93be57f47