### PR TITLE
Align Android client with network protocol v1.2.1 roster flow

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,12 @@
+# REPORT
+
+## Deviations Identified
+- **Start roster missing from client model:** The Android client previously ignored the `players` roster required in the `start` message, so downstream UI never received the authoritative player list once the match began. This also left the local role state stale after master hand-off.
+- **Snapshots never pruned vanished peers:** Remote player state was kept forever, even when the server broadcast a FULL snapshot without a given player, leading to ghost avatars after disconnects.
+- **Socket hard to exercise in tests:** `NetController` directly depended on `RtSocket`, preventing deterministic protocol tests and leaving the roster/backpressure logic untested against the updated spec.
+
+## Fixes Delivered
+- Added the roster payload to `S2CStart`, persisted it in `NetController`, and wired it into `NetState` so UI and character selection continue using the authoritative list during the running phase.
+- Updated `NetController` to rebuild its roster from lobby/start messages, react to role transfers, and drop remote players that disappear from FULL snapshots.
+- Introduced the `RtSocketClient` interface, allowing an in-memory fake for protocol unit tests and new coverage that ensures the first post-start snapshot is processed and remote peers are removed when absent from FULL snapshots.
+- Extended the shared wire definitions with the optional `character_select` client message so the Android build matches `NETWORK_PROTOCOL.md` v1.2.1.

--- a/androidApp/src/test/java/com/bene/jump/net/NetControllerTest.kt
+++ b/androidApp/src/test/java/com/bene/jump/net/NetControllerTest.kt
@@ -1,0 +1,237 @@
+package com.bene.jump.net
+
+import com.bene.jump.core.model.GameConfig
+import com.bene.jump.core.net.Envelope
+import com.bene.jump.core.net.LobbyPlayer
+import com.bene.jump.core.net.NetConfig
+import com.bene.jump.core.net.NetDifficultyCfg
+import com.bene.jump.core.net.NetPlayer
+import com.bene.jump.core.net.NetWorldCfg
+import com.bene.jump.core.net.PROTOCOL_VERSION
+import com.bene.jump.core.net.Role
+import com.bene.jump.core.net.RoomState
+import com.bene.jump.core.net.S2CSnapshot
+import com.bene.jump.core.net.S2CStart
+import com.bene.jump.core.net.S2CWelcome
+import com.bene.jump.core.net.S2CMessage
+import com.bene.jump.core.sim.GameSession
+import com.bene.jump.vm.PlayerUi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.standardTestDispatcher
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NetControllerTest {
+    private val session = GameSession(GameConfig(), seed = 1L)
+    private val dispatcher = standardTestDispatcher()
+    private val scope = TestScope(dispatcher)
+    private val socket = FakeSocket()
+    private var currentTime: Long = 0L
+    private val controller =
+        NetController(
+            session = session,
+            socket = socket,
+            scope = scope,
+            prefsStore = null,
+            clock = { currentTime },
+        )
+
+    @Test
+    fun `start roster updates lobby and role`() = runTest(dispatcher) {
+        startConnection()
+        val roster = roster()
+        emitWelcome(roster)
+        emitStart(roster)
+
+        val state = controller.state.value
+        assertEquals(RoomState.RUNNING, state.roomState)
+        assertEquals(roster, state.lobby)
+        assertEquals(Role.MASTER, state.role)
+    }
+
+    @Test
+    fun `full snapshot removes missing remote players`() = runTest(dispatcher) {
+        startConnection()
+        val roster = roster()
+        emitWelcome(roster)
+        emitStart(roster)
+
+        socket.emit(
+            RtSocket.Event.Message(
+                envelope(
+                    type = "snapshot",
+                    ts = 50L,
+                    payload =
+                        S2CSnapshot(
+                            tick = 10,
+                            ackTick = 10,
+                            lastInputSeq = 1,
+                            full = true,
+                            players =
+                                listOf(
+                                    NetPlayer(id = "p1", x = 1f, y = 2f, vx = 0f, vy = 0f, alive = true),
+                                    NetPlayer(id = "p2", x = 3f, y = 4f, vx = 0f, vy = 0f, alive = true),
+                                ),
+                            events = null,
+                            stats = null,
+                        ),
+                ),
+            ),
+        )
+        scope.runCurrent()
+
+        val remote = mutableListOf<PlayerUi>()
+        controller.sampleRemotePlayers(nowMs = 50L, out = remote)
+        assertEquals(1, remote.size)
+
+        socket.emit(
+            RtSocket.Event.Message(
+                envelope(
+                    type = "snapshot",
+                    ts = 100L,
+                    payload =
+                        S2CSnapshot(
+                            tick = 20,
+                            ackTick = 20,
+                            lastInputSeq = 2,
+                            full = true,
+                            players = listOf(NetPlayer(id = "p1", x = 2f, y = 3f, vx = 0f, vy = 0f, alive = true)),
+                            events = null,
+                            stats = null,
+                        ),
+                ),
+            ),
+        )
+        scope.runCurrent()
+
+        remote.clear()
+        controller.sampleRemotePlayers(nowMs = 100L, out = remote)
+        assertTrue(remote.isEmpty())
+    }
+
+    private suspend fun startConnection() {
+        controller.start(
+            NetController.Config(
+                roomId = "room1",
+                wsUrl = "ws://localhost",
+                playerName = "bene",
+                clientVersion = "test",
+                resumeToken = null,
+                playerId = null,
+                lastAckTick = null,
+                useInputBatch = false,
+                interpolationDelayMs = 0,
+            ),
+        )
+        scope.runCurrent()
+        socket.emit(RtSocket.Event.Opened)
+        scope.runCurrent()
+    }
+
+    private fun roster(): List<LobbyPlayer> =
+        listOf(
+            LobbyPlayer(id = "p1", name = "bene", ready = true, role = Role.MASTER, characterId = "aurora"),
+            LobbyPlayer(id = "p2", name = "ally", ready = true, role = Role.MEMBER, characterId = "cobalt"),
+        )
+
+    private suspend fun emitWelcome(players: List<LobbyPlayer>) {
+        socket.emit(
+            RtSocket.Event.Message(
+                envelope(
+                    type = "welcome",
+                    payload =
+                        S2CWelcome(
+                            playerId = "p1",
+                            resumeToken = "resume",
+                            roomId = "room1",
+                            seed = "1",
+                            role = Role.MASTER,
+                            roomState = RoomState.LOBBY,
+                            lobby = S2CWelcome.LobbySnapshot(players = players, maxPlayers = 4),
+                            cfg = netConfig(),
+                            featureFlags = null,
+                        ),
+                ),
+            ),
+        )
+        scope.runCurrent()
+    }
+
+    private suspend fun emitStart(players: List<LobbyPlayer>) {
+        socket.emit(
+            RtSocket.Event.Message(
+                envelope(
+                    type = "start",
+                    payload =
+                        S2CStart(
+                            startTick = 10,
+                            serverTick = 20,
+                            serverTimeMs = 100,
+                            tps = 60,
+                            players = players,
+                        ),
+                ),
+            ),
+        )
+        scope.runCurrent()
+    }
+
+    private fun envelope(
+        type: String,
+        payload: S2CMessage,
+        ts: Long = currentTime,
+    ): Envelope<S2CMessage> = Envelope(type, PROTOCOL_VERSION, 1u, ts, payload)
+
+    private fun netConfig(): NetConfig =
+        NetConfig(
+            tps = 60,
+            snapshotRateHz = 10,
+            maxRollbackTicks = 6,
+            inputLeadTicks = 2,
+            world =
+                NetWorldCfg(
+                    worldWidth = 100f,
+                    platformWidth = 10f,
+                    platformHeight = 2f,
+                    gapMin = 1f,
+                    gapMax = 2f,
+                    gravity = -9.8f,
+                    jumpVy = 5f,
+                    springVy = 7f,
+                    maxVx = 3f,
+                    tiltAccel = 0.5f,
+                ),
+            difficulty =
+                NetDifficultyCfg(
+                    gapMinStart = 1f,
+                    gapMinEnd = 1f,
+                    gapMaxStart = 2f,
+                    gapMaxEnd = 2f,
+                    springChanceStart = 0.1f,
+                    springChanceEnd = 0.2f,
+                ),
+        )
+
+    private inner class FakeSocket : RtSocketClient {
+        private val shared = MutableSharedFlow<RtSocket.Event>(extraBufferCapacity = 16)
+
+        override fun connect(wsUrl: String) = shared
+
+        override suspend fun send(obj: Any) {
+            // ignore sends in tests
+        }
+
+        override suspend fun close() {
+            // no-op
+        }
+
+        suspend fun emit(event: RtSocket.Event) {
+            shared.emit(event)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/com/bene/jump/core/net/Wire.kt
+++ b/core/src/commonMain/kotlin/com/bene/jump/core/net/Wire.kt
@@ -169,6 +169,10 @@ data class C2SReadySet(val ready: Boolean) : C2SMessage
 @SerialName("start_request")
 data class C2SStartRequest(val countdownSec: Int? = null) : C2SMessage
 
+@Serializable
+@SerialName("character_select")
+data class C2SCharacterSelect(val characterId: String) : C2SMessage
+
 // ----- Server → Client -----
 
 sealed interface S2CMessage
@@ -216,6 +220,7 @@ data class S2CStart(
     val serverTick: Int,
     val serverTimeMs: Long,
     val tps: Int,
+    val players: List<LobbyPlayer>,
 ) : S2CMessage
 
 @Serializable
@@ -365,6 +370,7 @@ fun encodeC2S(
         is C2SReconnect -> encodeEnvelope(Envelope("reconnect", PROTOCOL_VERSION, seq, ts, message), C2SReconnect.serializer())
         is C2SReadySet -> encodeEnvelope(Envelope("ready_set", PROTOCOL_VERSION, seq, ts, message), C2SReadySet.serializer())
         is C2SStartRequest -> encodeEnvelope(Envelope("start_request", PROTOCOL_VERSION, seq, ts, message), C2SStartRequest.serializer())
+        is C2SCharacterSelect -> encodeEnvelope(Envelope("character_select", PROTOCOL_VERSION, seq, ts, message), C2SCharacterSelect.serializer())
     }
 }
 

--- a/docs/LOCAL_RUN.md
+++ b/docs/LOCAL_RUN.md
@@ -1,0 +1,20 @@
+# Local Run Guide
+
+The Android client expects the lobby REST API and realtime WebSocket described in `NETWORK_PROTOCOL.md` (pv=1) to be available on localhost.
+
+## Prerequisites
+- Java 17+
+- Android SDK (compileSdk 35) if you plan to build the client locally.
+- A server implementation that honors `NETWORK_PROTOCOL.md` v1.2.1, exposing:
+  - `http://localhost:8080` for REST endpoints (e.g., `/v1/rooms`, `/v1/rooms/{id}/start`).
+  - `ws://localhost:8081/v1/ws` for realtime traffic.
+
+The Android build scripts already point to these URLs through `BuildConfig.API_BASE` and `BuildConfig.WS_URL`. When running on an emulator, these resolve to `10.0.2.2`, forwarding to the host machine.
+
+## Steps
+1. Start your backend server locally so that REST is reachable at `http://localhost:8080` and the WebSocket endpoint at `ws://localhost:8081/v1/ws`.
+2. In Android Studio (or via Gradle), build and install the `androidApp` module.
+3. Launch the app; create or join a room. The client will connect to the configured WebSocket and wait for the `start` payload (including the roster) before accepting inputs.
+
+## Testing
+- Run `./gradlew test` to execute the shared/unit tests. (An Android SDK must be present or Gradle will abort with an SDK error.)


### PR DESCRIPTION
## Summary
- update the shared wire schema to carry the start roster and expose the optional character_select message
- teach the Android NetController to keep the lobby roster through countdown/start, react to role changes, and prune remote peers missing from full snapshots
- introduce an RtSocketClient test seam and add unit tests plus local documentation/reporting for the roster flow

## Testing
- `./gradlew test` *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d57d105870832da0dcf9eaf43f3ec0