### PR TITLE
Fix ktlint formatting issues

### DIFF
--- a/core/src/commonMain/kotlin/com/bene/jump/core/net/Wire.kt
+++ b/core/src/commonMain/kotlin/com/bene/jump/core/net/Wire.kt
@@ -370,7 +370,11 @@ fun encodeC2S(
         is C2SReconnect -> encodeEnvelope(Envelope("reconnect", PROTOCOL_VERSION, seq, ts, message), C2SReconnect.serializer())
         is C2SReadySet -> encodeEnvelope(Envelope("ready_set", PROTOCOL_VERSION, seq, ts, message), C2SReadySet.serializer())
         is C2SStartRequest -> encodeEnvelope(Envelope("start_request", PROTOCOL_VERSION, seq, ts, message), C2SStartRequest.serializer())
-        is C2SCharacterSelect -> encodeEnvelope(Envelope("character_select", PROTOCOL_VERSION, seq, ts, message), C2SCharacterSelect.serializer())
+        is C2SCharacterSelect ->
+            encodeEnvelope(
+                Envelope("character_select", PROTOCOL_VERSION, seq, ts, message),
+                C2SCharacterSelect.serializer(),
+            )
     }
 }
 


### PR DESCRIPTION
## Summary
- reorder the test imports and adjust multiline formatting in `NetControllerTest` to satisfy ktlint
- wrap the long `C2SCharacterSelect` envelope encoding to meet ktlint line length rules

## Testing
- ./gradlew ktlintCheck

------
https://chatgpt.com/codex/tasks/task_e_68d628aa5184832db426c542b1d2ec94